### PR TITLE
V1.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.12.12
 
 # Mod Properties
-	mod_version = 1.0.1
+	mod_version = 1.1.0
 	maven_group = com.safetweaks
 	archives_base_name = safetweaks
 

--- a/src/main/java/net/fabricmc/safetweaks/SafeTweaksClient.java
+++ b/src/main/java/net/fabricmc/safetweaks/SafeTweaksClient.java
@@ -1,13 +1,12 @@
 package net.fabricmc.safetweaks;
 
 import net.fabricmc.api.ModInitializer;
-
-import net.fabricmc.safetweaks.config.FeatureFlagManager;
+// import net.fabricmc.safetweaks.config.FeatureFlagManager;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class InitializerMod implements ModInitializer {
+public class SafeTweaksClient implements ModInitializer {
 	// This logger is used to write text to the console and the log file.
 	// It is considered best practice to use your mod id as the logger's name.
 	// That way, it's clear which mod wrote info, warnings, and errors.
@@ -19,13 +18,20 @@ public class InitializerMod implements ModInitializer {
 		// However, some things (like resources) may still be uninitialized.
 		// Proceed with mild caution.
 
-        initializeFeatureFlags();
+        // Set feature flags on launch | Apparently mixin runs first...
+        // initializeFeatureFlags();
 
 		LOGGER.info("SafeTweaks init!");
 	}
 
-    private void initializeFeatureFlags() {
-        FeatureFlagManager featureFlags = FeatureFlagManager.getInstance();
-        featureFlags.set("renderDistanceFogToggle", false);
-    }
+    // private void initializeFeatureFlags() {
+    //     // Will populate from the given file in FeatureFlagManager constructor
+    //     FeatureFlagManager.getInstance((instance) -> {
+    //         // Skip setting defaults unless the flags are empty
+    //         if(instance.isEmpty()) { return; }
+
+    //         // Set default flags here
+    //         instance.set("renderDistanceFogToggle", false);
+    //     });
+    // }
 }

--- a/src/main/java/net/fabricmc/safetweaks/config/FeatureFlagManager.java
+++ b/src/main/java/net/fabricmc/safetweaks/config/FeatureFlagManager.java
@@ -1,8 +1,22 @@
 package net.fabricmc.safetweaks.config;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.Map;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.safetweaks.SafeTweaksClient;
 
 public class FeatureFlagManager {
+
+    public interface setDefaultCallback {
+        public void run(FeatureFlagManager i);
+    }
 
     public class FeatureMissingException extends RuntimeException {
         public FeatureMissingException(String msg) {
@@ -11,13 +25,25 @@ public class FeatureFlagManager {
     }
 
     private static final FeatureFlagManager instance = new FeatureFlagManager();
+    private final String filePath = FabricLoader.getInstance().getConfigDir().resolve("safetweaks-feature-flags.txt").toString();
 
     private HashMap<String, Boolean> FeatureFlags = new HashMap<String, Boolean>();
 
-    private FeatureFlagManager() {}
+    private FeatureFlagManager() {
+        setFromFile(filePath);
+    }
 
     public static FeatureFlagManager getInstance() {
         return instance;
+    }
+
+    public static FeatureFlagManager getInstance(setDefaultCallback overrideFlags) {
+        overrideFlags.run(instance);
+        return instance;
+    }
+
+    public Boolean isEmpty() {
+        return FeatureFlags.isEmpty();
     }
 
     public void set(String key, Boolean flag) {
@@ -30,5 +56,49 @@ public class FeatureFlagManager {
         } else {
             throw new FeatureMissingException("Key not found in features: " + key);
         }
+    }
+
+    // Set FeatureFlags from file for persistent flags
+    private void setFromFile(String filePath) {
+        try {
+            File file = new File(filePath);
+            file.createNewFile(); // Does nothing if file exists already
+        } catch (IOException e) {
+            SafeTweaksClient.LOGGER.error("Error reading flags: " + e.getMessage());
+        }
+
+
+        try(BufferedReader br = new BufferedReader(new FileReader(filePath))) {
+            String[] keyVal;
+            for(String line = br.readLine(); line != null; line = br.readLine()) {
+                keyVal = line.split("=");
+                FeatureFlags.put(keyVal[0], Boolean.parseBoolean(keyVal[1]));
+            }
+        } catch (IOException e) {
+            SafeTweaksClient.LOGGER.error("Could not read flags from file: " + e.getMessage());
+        }
+    }
+
+    // Write FeatureFlags to file in order to read on next init
+    private static void writeToFile(String path, HashMap<String, Boolean> flags) {
+        try {
+            File file = new File(path);
+            file.createNewFile(); // Does nothing if file exists already
+
+            PrintWriter pr = new PrintWriter(new File(path));
+            for (Map.Entry<String, Boolean> entry : flags.entrySet()) {
+                pr.println(entry.getKey() + "=" + entry.getValue().toString());
+            }
+            pr.close();
+        } catch (FileNotFoundException e) {
+            SafeTweaksClient.LOGGER.error("Error writing flags: " + e.getMessage());
+        } catch (IOException e) {
+            SafeTweaksClient.LOGGER.error("Error writing flags: " + e.getMessage());
+        }
+    }
+
+    // Wrapper for writing feature flags to file
+    public static void saveFlagsPersistent() {
+        writeToFile(instance.filePath, instance.FeatureFlags);
     }
 }

--- a/src/main/java/net/fabricmc/safetweaks/config/FeatureFlagManager.java
+++ b/src/main/java/net/fabricmc/safetweaks/config/FeatureFlagManager.java
@@ -85,15 +85,15 @@ public class FeatureFlagManager {
             File file = new File(path);
             file.createNewFile(); // Does nothing if file exists already
 
-            PrintWriter pr = new PrintWriter(new File(path));
+            PrintWriter pr = new PrintWriter(file);
             for (Map.Entry<String, Boolean> entry : flags.entrySet()) {
                 pr.println(entry.getKey() + "=" + entry.getValue().toString());
             }
             pr.close();
         } catch (FileNotFoundException e) {
-            SafeTweaksClient.LOGGER.error("Error writing flags: " + e.getMessage());
+            SafeTweaksClient.LOGGER.error("Error writing feature flags: " + e.getMessage());
         } catch (IOException e) {
-            SafeTweaksClient.LOGGER.error("Error writing flags: " + e.getMessage());
+            SafeTweaksClient.LOGGER.error("Error writing feature flags: " + e.getMessage());
         }
     }
 

--- a/src/main/java/net/fabricmc/safetweaks/mixin/BackgroundRendererMixin.java
+++ b/src/main/java/net/fabricmc/safetweaks/mixin/BackgroundRendererMixin.java
@@ -106,14 +106,19 @@ public class BackgroundRendererMixin {
         {
             if (thickFog == false && wasLava == false)
             {
-                MinecraftClient mc = MinecraftClient.getInstance();
-                try {
-                    float distance = Math.max(512, mc.gameRenderer.getViewDistance());
-                    RenderSystem.setShaderFogStart(distance * 1.6F);
-                    RenderSystem.setShaderFogEnd(distance * 2.0F);
-                } finally {
-                    mc.close();
-                }
+                // Attempt to clean resource leak
+                // MinecraftClient mc = MinecraftClient.getInstance();
+                // try {
+                //     float distance = Math.max(512, mc.gameRenderer.getViewDistance());
+                //     RenderSystem.setShaderFogStart(distance * 1.6F);
+                //     RenderSystem.setShaderFogEnd(distance * 2.0F);
+                // } finally {
+                //     mc.close();
+                // }
+
+                float distance = Math.max(512, MinecraftClient.getInstance().gameRenderer.getViewDistance());
+                RenderSystem.setShaderFogStart(distance * 1.6F);
+                RenderSystem.setShaderFogEnd(distance * 2.0F);
             }
 
             wasLava = false;

--- a/src/main/java/net/fabricmc/safetweaks/mixin/BackgroundRendererMixin.java
+++ b/src/main/java/net/fabricmc/safetweaks/mixin/BackgroundRendererMixin.java
@@ -106,7 +106,7 @@ public class BackgroundRendererMixin {
         {
             if (thickFog == false && wasLava == false)
             {
-                // Attempt to clean resource leak
+                // Attempt to clean possible resource leak
                 // MinecraftClient mc = MinecraftClient.getInstance();
                 // try {
                 //     float distance = Math.max(512, mc.gameRenderer.getViewDistance());

--- a/src/main/java/net/fabricmc/safetweaks/mixin/BackgroundRendererMixin.java
+++ b/src/main/java/net/fabricmc/safetweaks/mixin/BackgroundRendererMixin.java
@@ -1,6 +1,7 @@
 package net.fabricmc.safetweaks.mixin;
 
 // Taken from the temporary 1.18 implementation of tweakeroo: https://github.com/maruohon/tweakeroo/blob/fabric_1.18_temp_features/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinBackgroundRenderer.java
+// Minor edits made from the tweakeroo implementation
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
@@ -105,9 +106,14 @@ public class BackgroundRendererMixin {
         {
             if (thickFog == false && wasLava == false)
             {
-                float distance = Math.max(512, MinecraftClient.getInstance().gameRenderer.getViewDistance());
-                RenderSystem.setShaderFogStart(distance * 1.6F);
-                RenderSystem.setShaderFogEnd(distance * 2.0F);
+                MinecraftClient mc = MinecraftClient.getInstance();
+                try {
+                    float distance = Math.max(512, mc.gameRenderer.getViewDistance());
+                    RenderSystem.setShaderFogStart(distance * 1.6F);
+                    RenderSystem.setShaderFogEnd(distance * 2.0F);
+                } finally {
+                    mc.close();
+                }
             }
 
             wasLava = false;

--- a/src/main/java/net/fabricmc/safetweaks/mixin/EntryMixin.java
+++ b/src/main/java/net/fabricmc/safetweaks/mixin/EntryMixin.java
@@ -1,7 +1,6 @@
 package net.fabricmc.safetweaks.mixin;
 
 import net.fabricmc.safetweaks.SafeTweaksClient;
-import net.fabricmc.safetweaks.config.FeatureFlagManager;
 import net.minecraft.client.gui.screen.TitleScreen;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,6 +12,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class EntryMixin {
 	@Inject(at = @At("HEAD"), method = "init()V")
 	private void init(CallbackInfo info) {
-		SafeTweaksClient.LOGGER.info("This line is printed from SafeTweaks!");
+		SafeTweaksClient.LOGGER.info("SafeTweaks mixin entrypoint");
     }
 }

--- a/src/main/java/net/fabricmc/safetweaks/mixin/EntryMixin.java
+++ b/src/main/java/net/fabricmc/safetweaks/mixin/EntryMixin.java
@@ -1,6 +1,7 @@
 package net.fabricmc.safetweaks.mixin;
 
-import net.fabricmc.safetweaks.InitializerMod;
+import net.fabricmc.safetweaks.SafeTweaksClient;
+import net.fabricmc.safetweaks.config.FeatureFlagManager;
 import net.minecraft.client.gui.screen.TitleScreen;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,6 +13,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class EntryMixin {
 	@Inject(at = @At("HEAD"), method = "init()V")
 	private void init(CallbackInfo info) {
-		InitializerMod.LOGGER.info("This line is printed from SafeTweaks!");
+		SafeTweaksClient.LOGGER.info("This line is printed from SafeTweaks!");
     }
 }

--- a/src/main/java/net/fabricmc/safetweaks/modmenu/ClothConfigModMenu.java
+++ b/src/main/java/net/fabricmc/safetweaks/modmenu/ClothConfigModMenu.java
@@ -9,9 +9,13 @@ import net.minecraft.text.TranslatableText;
 
 public class ClothConfigModMenu {
 
-    private static FeatureFlagManager featureFlags = FeatureFlagManager.getInstance();
+    private static FeatureFlagManager featureFlags = FeatureFlagManager.getInstance((instance) -> {
+        // Skip setting defaults unless the flags are empty
+        if(!instance.isEmpty()) { return; }
 
-
+        // Set default flags here
+        instance.set("renderDistanceFogToggle", false);
+    });
 
     public static ConfigBuilder getConfigBuilderWithOptions() {
 
@@ -33,6 +37,11 @@ public class ClothConfigModMenu {
 
         // Render distance fog override tweak
         tweaks.addEntry(entryBuilder.startBooleanToggle(new TranslatableText("config.safetweaks.render-distance-fog"), featureFlags.get("renderDistanceFogToggle")).setDefaultValue(false).setSaveConsumer((newVal) -> { featureFlags.set("renderDistanceFogToggle", newVal); }).build());
+
+        // On save
+        builder.setSavingRunnable(() -> {
+            FeatureFlagManager.saveFlagsPersistent();
+        });
 
         // Returning the builder
         builder.transparentBackground();

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
   "environment": "*",
   "entrypoints": {
     "main": [
-      "net.fabricmc.safetweaks.InitializerMod"
+      "net.fabricmc.safetweaks.SafeTweaksClient"
     ],
     "modmenu": [
       "net.fabricmc.safetweaks.modmenu.ModMenuIntegration"


### PR DESCRIPTION
## Summary of change

Implement persistence for toggles

## Description of change

We now will populate the FeatureFlags HashMap with the contents of config file `safetweaks-feature-flags.txt`

Accepts the following format:

```text
flag1=true
flag2=false
```

Likewise on saving in the config menu it will write the current FeatureFlags from the current instance of FeatureFlagManager to this file.